### PR TITLE
Run content script at document start to avoid content flash

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "content_scripts": [
     {
+      "run_at": "document_start",
       "css": [
         "linkedin-feed-blocker.css"
       ],


### PR DESCRIPTION
Thanks for maintaining the addon!

This fixes a brief flash of the newsfeed by loading the CSS before the page loads. I've tested it locally 👍 